### PR TITLE
feat: Offline Signer Auto

### DIFF
--- a/.changeset/late-melons-swim.md
+++ b/.changeset/late-melons-swim.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/wallet-connector": patch
+---
+
+Offline Signer Auto

--- a/README.md
+++ b/README.md
@@ -215,10 +215,10 @@ export interface IBBNProvider extends IProvider {
    * Retrieves an offline signer that supports both Amino and Direct signing methods.
    * This signer is used for signing transactions offline before broadcasting them to the network.
    *
-   * @returns {Promise<OfflineAminoSigner & OfflineDirectSigner>} A promise that resolves to a signer supporting both Amino and Direct signing
+   * @returns {Promise<OfflineAminoSigner | OfflineDirectSigner>} A promise that resolves to a signer supporting either Amino or Direct signing
    * @throws {Error} If wallet connection is not established or signer cannot be retrieved
    */
-  getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner>;
+  getOfflineSigner(): Promise<OfflineAminoSigner | OfflineDirectSigner>;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -215,10 +215,10 @@ export interface IBBNProvider extends IProvider {
    * Retrieves an offline signer that supports both Amino and Direct signing methods.
    * This signer is used for signing transactions offline before broadcasting them to the network.
    *
-   * @returns {Promise<OfflineAminoSigner | OfflineDirectSigner>} A promise that resolves to a signer supporting either Amino or Direct signing
+   * @returns {Promise<OfflineAminoSigner & OfflineDirectSigner>} A promise that resolves to a signer supporting both Amino and Direct signing
    * @throws {Error} If wallet connection is not established or signer cannot be retrieved
    */
-  getOfflineSigner(): Promise<OfflineAminoSigner | OfflineDirectSigner>;
+  getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner>;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,16 @@ export interface IBBNProvider extends IProvider {
    * @throws {Error} If wallet connection is not established or signer cannot be retrieved
    */
   getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner>;
+
+  /**
+   * Retrieves an offline signer that supports either Amino or Direct signing methods.
+   * This is required for compatibility with older wallets and hardware wallets (like Ledger) that do not support both signing methods.
+   * This signer is used for signing transactions offline before broadcasting them to the network.
+   *
+   * @returns {Promise<OfflineAminoSigner & OfflineDirectSigner>} A promise that resolves to a signer supporting either Amino or Direct signing
+   * @throws {Error} If wallet connection is not established or signer cannot be retrieved
+   */
+  getOfflineSignerAuto?(): Promise<OfflineAminoSigner | OfflineDirectSigner>;
 }
 ```
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -257,8 +257,8 @@ export interface IBBNProvider extends IProvider {
    * Retrieves an offline signer that supports both Amino and Direct signing methods.
    * This signer is used for signing transactions offline before broadcasting them to the network.
    *
-   * @returns {Promise<OfflineAminoSigner & OfflineDirectSigner>} A promise that resolves to a signer supporting both Amino and Direct signing
+   * @returns {Promise<OfflineAminoSigner | OfflineDirectSigner>} A promise that resolves to a signer supporting either Amino or Direct signing
    * @throws {Error} If wallet connection is not established or signer cannot be retrieved
    */
-  getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner>;
+  getOfflineSigner(): Promise<OfflineAminoSigner | OfflineDirectSigner>;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -261,4 +261,14 @@ export interface IBBNProvider extends IProvider {
    * @throws {Error} If wallet connection is not established or signer cannot be retrieved
    */
   getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner>;
+
+  /**
+   * Retrieves an offline signer that supports either Amino or Direct signing methods.
+   * This is required for compatibility with older wallets and hardware wallets (like Ledger) that do not support both signing methods.
+   * This signer is used for signing transactions offline before broadcasting them to the network.
+   *
+   * @returns {Promise<OfflineAminoSigner & OfflineDirectSigner>} A promise that resolves to a signer supporting either Amino or Direct signing
+   * @throws {Error} If wallet connection is not established or signer cannot be retrieved
+   */
+  getOfflineSignerAuto?(): Promise<OfflineAminoSigner | OfflineDirectSigner>;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -257,8 +257,8 @@ export interface IBBNProvider extends IProvider {
    * Retrieves an offline signer that supports both Amino and Direct signing methods.
    * This signer is used for signing transactions offline before broadcasting them to the network.
    *
-   * @returns {Promise<OfflineAminoSigner | OfflineDirectSigner>} A promise that resolves to a signer supporting either Amino or Direct signing
+   * @returns {Promise<OfflineAminoSigner & OfflineDirectSigner>} A promise that resolves to a signer supporting both Amino and Direct signing
    * @throws {Error} If wallet connection is not established or signer cannot be retrieved
    */
-  getOfflineSigner(): Promise<OfflineAminoSigner | OfflineDirectSigner>;
+  getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner>;
 }

--- a/src/core/wallets/bbn/keplr/provider.ts
+++ b/src/core/wallets/bbn/keplr/provider.ts
@@ -91,12 +91,12 @@ export class KeplrProvider implements IBBNProvider {
     return logo;
   }
 
-  async getOfflineSigner(): Promise<OfflineAminoSigner | OfflineDirectSigner> {
+  async getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner> {
     if (!this.keplr) throw new Error("Keplr extension not found");
     if (!this.chainId) throw new Error("Chain ID is not initialized");
 
     try {
-      return this.keplr.getOfflineSignerAuto(this.chainId);
+      return this.keplr.getOfflineSigner(this.chainId);
     } catch {
       throw new Error("Failed to get offline signer");
     }

--- a/src/core/wallets/bbn/keplr/provider.ts
+++ b/src/core/wallets/bbn/keplr/provider.ts
@@ -101,4 +101,15 @@ export class KeplrProvider implements IBBNProvider {
       throw new Error("Failed to get offline signer");
     }
   }
+
+  async getOfflineSignerAuto(): Promise<OfflineAminoSigner | OfflineDirectSigner> {
+    if (!this.keplr) throw new Error("Keplr extension not found");
+    if (!this.chainId) throw new Error("Chain ID is not initialized");
+
+    try {
+      return this.keplr.getOfflineSignerAuto(this.chainId);
+    } catch {
+      throw new Error("Failed to get offline signer auto");
+    }
+  }
 }

--- a/src/core/wallets/bbn/keplr/provider.ts
+++ b/src/core/wallets/bbn/keplr/provider.ts
@@ -91,12 +91,12 @@ export class KeplrProvider implements IBBNProvider {
     return logo;
   }
 
-  async getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner> {
+  async getOfflineSigner(): Promise<OfflineAminoSigner | OfflineDirectSigner> {
     if (!this.keplr) throw new Error("Keplr extension not found");
     if (!this.chainId) throw new Error("Chain ID is not initialized");
 
     try {
-      return this.keplr.getOfflineSigner(this.chainId);
+      return this.keplr.getOfflineSignerAuto(this.chainId);
     } catch {
       throw new Error("Failed to get offline signer");
     }

--- a/src/core/wallets/bbn/leap/provider.ts
+++ b/src/core/wallets/bbn/leap/provider.ts
@@ -95,4 +95,15 @@ export class LeapProvider implements IBBNProvider {
       throw new Error("Failed to get offline signer");
     }
   }
+
+  async getOfflineSignerAuto(): Promise<OfflineAminoSigner | OfflineDirectSigner> {
+    if (!this.wallet) throw new Error("Leap extension not found");
+    if (!this.chainId) throw new Error("Chain ID is not initialized");
+
+    try {
+      return this.wallet.getOfflineSignerAuto(this.chainId);
+    } catch {
+      throw new Error("Failed to get offline signer auto");
+    }
+  }
 }

--- a/src/core/wallets/bbn/leap/provider.ts
+++ b/src/core/wallets/bbn/leap/provider.ts
@@ -90,7 +90,6 @@ export class LeapProvider implements IBBNProvider {
     if (!this.chainId) throw new Error("Chain ID is not initialized");
 
     try {
-      console.log("leap provider getOfflineSignerAuto");
       return this.wallet.getOfflineSignerAuto(this.chainId);
     } catch {
       throw new Error("Failed to get offline signer");

--- a/src/core/wallets/bbn/leap/provider.ts
+++ b/src/core/wallets/bbn/leap/provider.ts
@@ -85,12 +85,12 @@ export class LeapProvider implements IBBNProvider {
     return logo;
   }
 
-  async getOfflineSigner(): Promise<OfflineAminoSigner | OfflineDirectSigner> {
+  async getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner> {
     if (!this.wallet) throw new Error("Leap extension not found");
     if (!this.chainId) throw new Error("Chain ID is not initialized");
 
     try {
-      return this.wallet.getOfflineSignerAuto(this.chainId);
+      return this.wallet.getOfflineSigner(this.chainId);
     } catch {
       throw new Error("Failed to get offline signer");
     }

--- a/src/core/wallets/bbn/leap/provider.ts
+++ b/src/core/wallets/bbn/leap/provider.ts
@@ -85,12 +85,13 @@ export class LeapProvider implements IBBNProvider {
     return logo;
   }
 
-  async getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner> {
+  async getOfflineSigner(): Promise<OfflineAminoSigner | OfflineDirectSigner> {
     if (!this.wallet) throw new Error("Leap extension not found");
     if (!this.chainId) throw new Error("Chain ID is not initialized");
 
     try {
-      return this.wallet.getOfflineSigner(this.chainId);
+      console.log("leap provider getOfflineSignerAuto");
+      return this.wallet.getOfflineSignerAuto(this.chainId);
     } catch {
       throw new Error("Failed to get offline signer");
     }

--- a/src/core/wallets/bbn/okx/provider.ts
+++ b/src/core/wallets/bbn/okx/provider.ts
@@ -95,4 +95,15 @@ export class OKXBabylonProvider implements IBBNProvider {
       throw new Error("Failed to get offline signer");
     }
   }
+
+  async getOfflineSignerAuto(): Promise<OfflineAminoSigner | OfflineDirectSigner> {
+    if (!this.wallet.keplr) throw new Error("OKX Wallet extension not found");
+    if (!this.chainId) throw new Error("Chain ID is not initialized");
+
+    try {
+      return this.wallet.keplr.getOfflineSignerAuto(this.chainId);
+    } catch {
+      throw new Error("Failed to get offline signer auto");
+    }
+  }
 }

--- a/src/core/wallets/bbn/okx/provider.ts
+++ b/src/core/wallets/bbn/okx/provider.ts
@@ -85,12 +85,12 @@ export class OKXBabylonProvider implements IBBNProvider {
     return logo;
   }
 
-  async getOfflineSigner(): Promise<OfflineAminoSigner | OfflineDirectSigner> {
+  async getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner> {
     if (!this.wallet.keplr) throw new Error("OKX Wallet extension not found");
     if (!this.chainId) throw new Error("Chain ID is not initialized");
 
     try {
-      return this.wallet.keplr.getOfflineSignerAuto(this.chainId);
+      return this.wallet.keplr.getOfflineSigner(this.chainId);
     } catch {
       throw new Error("Failed to get offline signer");
     }

--- a/src/core/wallets/bbn/okx/provider.ts
+++ b/src/core/wallets/bbn/okx/provider.ts
@@ -85,12 +85,12 @@ export class OKXBabylonProvider implements IBBNProvider {
     return logo;
   }
 
-  async getOfflineSigner(): Promise<OfflineAminoSigner & OfflineDirectSigner> {
+  async getOfflineSigner(): Promise<OfflineAminoSigner | OfflineDirectSigner> {
     if (!this.wallet.keplr) throw new Error("OKX Wallet extension not found");
     if (!this.chainId) throw new Error("Chain ID is not initialized");
 
     try {
-      return this.wallet.keplr.getOfflineSigner(this.chainId);
+      return this.wallet.keplr.getOfflineSignerAuto(this.chainId);
     } catch {
       throw new Error("Failed to get offline signer");
     }


### PR DESCRIPTION
`OfflineAminoSigner & OfflineDirectSigner` -> `OfflineAminoSigner | OfflineDirectSigner`. Compatible with `import { OfflineSigner } from "@cosmjs/proto-signing";` 

So if wallet thinks `OfflineAminoSigner` signer should be used, it returns it. If `Direct` is enough - returns `OfflineDirectSigner`.
Note: we are offloading this to the wallet itself, and not using `if account.isNanoLedger` or whatever, since these flags can change

Current approach in this PR works on both Keplr and Leap. OKX does not allow Ledger Cosmos connection.