### PR TITLE
feat: Babylon Cosmos wallets onChange

### DIFF
--- a/.changeset/empty-tomatoes-suffer.md
+++ b/.changeset/empty-tomatoes-suffer.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/wallet-connector": patch
+---
+
+on off for babylon wallets

--- a/README.md
+++ b/README.md
@@ -229,6 +229,21 @@ export interface IBBNProvider extends IProvider {
    * @throws {Error} If wallet connection is not established or signer cannot be retrieved
    */
   getOfflineSignerAuto?(): Promise<OfflineAminoSigner | OfflineDirectSigner>;
+
+  /**
+   * Registers an event listener for the specified event.
+   * At the moment, only the "accountChanged" event is supported.
+   * @param eventName - The name of the event to listen for.
+   * @param callBack - The callback function to be executed when the event occurs.
+   */
+  on(eventName: string, callBack: () => void): void;
+
+  /**
+   * Unregisters an event listener for the specified event.
+   * @param eventName - The name of the event to listen for.
+   * @param callBack - The callback function to be executed when the event occurs.
+   */
+  off(eventName: string, callBack: () => void): void;
 }
 ```
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -271,4 +271,19 @@ export interface IBBNProvider extends IProvider {
    * @throws {Error} If wallet connection is not established or signer cannot be retrieved
    */
   getOfflineSignerAuto?(): Promise<OfflineAminoSigner | OfflineDirectSigner>;
+
+  /**
+   * Registers an event listener for the specified event.
+   * At the moment, only the "accountChanged" event is supported.
+   * @param eventName - The name of the event to listen for.
+   * @param callBack - The callback function to be executed when the event occurs.
+   */
+  on(eventName: string, callBack: () => void): void;
+
+  /**
+   * Unregisters an event listener for the specified event.
+   * @param eventName - The name of the event to listen for.
+   * @param callBack - The callback function to be executed when the event occurs.
+   */
+  off(eventName: string, callBack: () => void): void;
 }

--- a/src/core/wallets/bbn/keplr/provider.ts
+++ b/src/core/wallets/bbn/keplr/provider.ts
@@ -112,4 +112,18 @@ export class KeplrProvider implements IBBNProvider {
       throw new Error("Failed to get offline signer auto");
     }
   }
+
+  on = (eventName: string, callBack: () => void) => {
+    if (!this.walletInfo) throw new Error("Wallet not connected");
+    if (eventName === "accountChanged") {
+      window.addEventListener("keplr_keystorechange", callBack);
+    }
+  };
+
+  off = (eventName: string, callBack: () => void) => {
+    if (!this.walletInfo) throw new Error("Wallet not connected");
+    if (eventName === "accountChanged") {
+      window.removeEventListener("keplr_keystorechange", callBack);
+    }
+  };
 }

--- a/src/core/wallets/bbn/leap/provider.ts
+++ b/src/core/wallets/bbn/leap/provider.ts
@@ -106,4 +106,18 @@ export class LeapProvider implements IBBNProvider {
       throw new Error("Failed to get offline signer auto");
     }
   }
+
+  on = (eventName: string, callBack: () => void) => {
+    if (!this.walletInfo) throw new Error("Wallet not connected");
+    if (eventName === "accountChanged") {
+      window.addEventListener("leap_keystorechange", callBack);
+    }
+  };
+
+  off = (eventName: string, callBack: () => void) => {
+    if (!this.walletInfo) throw new Error("Wallet not connected");
+    if (eventName === "accountChanged") {
+      window.removeEventListener("leap_keystorechange", callBack);
+    }
+  };
 }

--- a/src/core/wallets/bbn/okx/provider.ts
+++ b/src/core/wallets/bbn/okx/provider.ts
@@ -106,4 +106,20 @@ export class OKXBabylonProvider implements IBBNProvider {
       throw new Error("Failed to get offline signer auto");
     }
   }
+
+  on = (eventName: string, callBack: () => void) => {
+    if (!this.walletInfo) throw new Error("Wallet not connected");
+    if (eventName === "accountChanged") {
+      // currently the event is not implemented
+      window.addEventListener("okx_keystorechange", callBack);
+    }
+  };
+
+  off = (eventName: string, callBack: () => void) => {
+    if (!this.walletInfo) throw new Error("Wallet not connected");
+    if (eventName === "accountChanged") {
+      // currently the event is not implemented
+      window.removeEventListener("okx_keystorechange", callBack);
+    }
+  };
 }


### PR DESCRIPTION
- Adds `on` and `off` events for `cosmos` wallets, similar to `bitcoin` wallets
- Attaches to the proper window `event`
  - `OKX` is not there yet, but the assumption is made
  - In case they change the naming to something different, this particular string can be changed
- Update the interface and Readme
- Outside usage is the same as for `btc` wallets - `accountChange` event

Closes #260 