### PR TITLE
WIP: Keplr occupied warning

### DIFF
--- a/src/core/wallets/bbn/keplr/provider.ts
+++ b/src/core/wallets/bbn/keplr/provider.ts
@@ -31,10 +31,26 @@ export class KeplrProvider implements IBBNProvider {
     this.chainData = config.chainData;
   }
 
+  isRealKeplr() {
+    return (
+      typeof this?.keplr?.signEthereum === "function" ||
+      typeof this?.keplr?.sendEthereumTx === "function" ||
+      (this?.keplr?.defaultOptions && typeof this?.keplr?.defaultOptions === "object")
+    );
+  }
+
   async connectWallet(): Promise<void> {
     if (!this.chainId) throw new Error("Chain ID is not initialized");
     if (!this.rpc) throw new Error("RPC URL is not initialized");
     if (!this.keplr) throw new Error("Keplr extension not found");
+
+    const notRealKeplrFlags = ["isBitKeep", "isOneKey", "isOkxWallet"];
+    const keplrHasFlags = notRealKeplrFlags.some((flag) => (this.keplr as any)?.[flag]);
+
+    if (!this.isRealKeplr() || keplrHasFlags) {
+      console.log("not real keplr");
+      throw new Error("Keplr extension not found");
+    }
 
     try {
       await this.keplr.enable(this.chainId);


### PR DESCRIPTION
Checks out that Keplr is occupied

Additional:
- Currently we check what *is not* `keplr` (`isOkxWallet` for example) 
- And add a bit of *what is* `keplr`. Keplr team can provide additional details on that, so the check out logic is better.
- UI modal / warning should be triggered