### PR TITLE
feat: BIP322 signMessage for software wallets

### DIFF
--- a/.changeset/fair-lions-dress.md
+++ b/.changeset/fair-lions-dress.md
@@ -1,0 +1,5 @@
+---
+"@babylonlabs-io/wallet-connector": patch
+---
+
+bip322 signMessage as default for software wallets

--- a/README.md
+++ b/README.md
@@ -134,12 +134,15 @@ interface IBTCProvider extends IProvider {
   getNetwork(): Promise<Network>;
 
   /**
-   * Signs a message using the specified signing method.
+   * Signs a message using either BIP322-Simple or ECDSA signing method.
    * @param message - The message to sign.
    * @param type - The signing method to use.
    * @returns A promise that resolves to the signed message.
    */
-  signMessage(message: string, type: "ecdsa"): Promise<string>;
+  signMessage(
+    message: string,
+    type: "bip322-simple" | "ecdsa",
+  ): Promise<string>;
 
   /**
    * Retrieves the inscriptions for the connected wallet.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -180,12 +180,12 @@ export interface IBTCProvider extends IProvider {
   getNetwork(): Promise<Network>;
 
   /**
-   * Signs a message using the specified signing method.
+   * Signs a message using either BIP322-Simple or ECDSA signing method.
    * @param message - The message to sign.
    * @param type - The signing method to use.
    * @returns A promise that resolves to the signed message.
    */
-  signMessage(message: string, type: "ecdsa"): Promise<string>;
+  signMessage(message: string, type: "bip322-simple" | "ecdsa"): Promise<string>;
 
   /**
    * Retrieves the inscriptions for the connected wallet.

--- a/src/core/wallets/btc/okx/provider.ts
+++ b/src/core/wallets/btc/okx/provider.ts
@@ -102,7 +102,7 @@ export class OKXProvider implements IBTCProvider {
     return this.config.network;
   };
 
-  signMessage = async (message: string, type: "ecdsa"): Promise<string> => {
+  signMessage = async (message: string, type: "bip322-simple" | "ecdsa"): Promise<string> => {
     if (!this.walletInfo) throw new Error("OKX Wallet not connected");
 
     return await this.provider.signMessage(message, type);

--- a/src/core/wallets/btc/onekey/provider.ts
+++ b/src/core/wallets/btc/onekey/provider.ts
@@ -96,7 +96,7 @@ export class OneKeyProvider implements IBTCProvider {
     throw new Error("Unsupported network");
   };
 
-  signMessage = async (message: string, type: "ecdsa"): Promise<string> => {
+  signMessage = async (message: string, type: "bip322-simple" | "ecdsa"): Promise<string> => {
     if (!this.walletInfo) throw new Error("OneKey Wallet not connected");
 
     return await this.provider.signMessage(message, type);

--- a/src/core/wallets/btc/unisat/provider.ts
+++ b/src/core/wallets/btc/unisat/provider.ts
@@ -175,7 +175,7 @@ export class UnisatProvider implements IBTCProvider {
     }
   };
 
-  signMessage = async (message: string, type: "ecdsa"): Promise<string> => {
+  signMessage = async (message: string, type: "bip322-simple" | "ecdsa"): Promise<string> => {
     if (!this.walletInfo) throw new Error("Unisat Wallet not connected");
 
     return await this.provider.signMessage(message, type);


### PR DESCRIPTION
Adds an ability to use `bip322-simple` for software wallets
Keystone is extracted to a separate issue: https://github.com/babylonlabs-io/wallet-connector/issues/273