### PR TITLE
feat: Unisat contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,16 +151,21 @@ interface IBTCProvider extends IProvider {
   /**
    * Signs the given PSBT in hex format.
    * @param psbtHex - The hex string of the unsigned PSBT to sign.
+   * @param options - Optional parameters for signing the PSBT.
    * @returns A promise that resolves to the hex string of the signed PSBT.
    */
-  signPsbt(psbtHex: string): Promise<string>;
+  signPsbt(psbtHex: string, options?: SignPsbtOptions): Promise<string>;
 
   /**
    * Signs multiple PSBTs in hex format.
    * @param psbtsHexes - The hex strings of the unsigned PSBTs to sign.
+   * @param options - Optional parameters for signing the PSBTs.
    * @returns A promise that resolves to an array of hex strings, each representing a signed PSBT.
    */
-  signPsbts(psbtsHexes: string[]): Promise<string[]>;
+  signPsbts(
+    psbtsHexes: string[],
+    options?: SignPsbtOptions[],
+  ): Promise<string[]>;
 
   /**
    * Gets the network of the current account.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -151,20 +151,32 @@ export interface ExternalConnector<P extends IProvider = IProvider> {
   widget: WidgetComponent<P>;
 }
 
+export interface Contract {
+  id: string;
+  params: Record<string, string | number | string[] | number[]>;
+}
+
+export interface SignPsbtOptions {
+  autoFinalized?: boolean;
+  contracts?: Contract[];
+}
+
 export interface IBTCProvider extends IProvider {
   /**
    * Signs the given PSBT in hex format.
    * @param psbtHex - The hex string of the unsigned PSBT to sign.
+   * @param options - Optional parameters for signing the PSBT.
    * @returns A promise that resolves to the hex string of the signed PSBT.
    */
-  signPsbt(psbtHex: string): Promise<string>;
+  signPsbt(psbtHex: string, options?: SignPsbtOptions): Promise<string>;
 
   /**
    * Signs multiple PSBTs in hex format.
    * @param psbtsHexes - The hex strings of the unsigned PSBTs to sign.
+   * @param options - Optional parameters for signing the PSBTs.
    * @returns A promise that resolves to an array of hex strings, each representing a signed PSBT.
    */
-  signPsbts(psbtsHexes: string[]): Promise<string[]>;
+  signPsbts(psbtsHexes: string[], options?: SignPsbtOptions[]): Promise<string[]>;
 
   /**
    * Gets the network of the current account.

--- a/src/core/wallets/btc/unisat/provider.ts
+++ b/src/core/wallets/btc/unisat/provider.ts
@@ -1,7 +1,7 @@
 import { initBTCCurve } from "@babylonlabs-io/btc-staking-ts";
 import { Psbt, address as btcAddress, networks } from "bitcoinjs-lib";
 
-import type { BTCConfig, IBTCProvider, InscriptionIdentifier, WalletInfo } from "@/core/types";
+import type { BTCConfig, IBTCProvider, InscriptionIdentifier, SignPsbtOptions, WalletInfo } from "@/core/types";
 import { Network } from "@/core/types";
 import { ERROR_CODES, WalletError } from "@/error";
 
@@ -103,7 +103,7 @@ export class UnisatProvider implements IBTCProvider {
     return this.walletInfo.publicKeyHex;
   };
 
-  signPsbt = async (psbtHex: string): Promise<string> => {
+  signPsbt = async (psbtHex: string, options?: SignPsbtOptions): Promise<string> => {
     if (!this.walletInfo)
       throw new WalletError({
         code: ERROR_CODES.WALLET_NOT_CONNECTED,
@@ -119,7 +119,12 @@ export class UnisatProvider implements IBTCProvider {
 
     const network = await this.getNetwork();
     try {
-      const signedHex = await this.provider.signPsbt(psbtHex, this.getSignPsbtDefaultOptions(psbtHex, network));
+      const defaultOptions = this.getSignPsbtDefaultOptions(psbtHex, network);
+      const signOptions = {
+        ...defaultOptions,
+        ...options,
+      };
+      const signedHex = await this.provider.signPsbt(psbtHex, signOptions);
       return signedHex;
     } catch (error: Error | any) {
       throw new WalletError({
@@ -130,7 +135,8 @@ export class UnisatProvider implements IBTCProvider {
     }
   };
 
-  signPsbts = async (psbtsHexes: string[]): Promise<string[]> => {
+  // Order of PSBTs in the array must be the same as the order of options
+  signPsbts = async (psbtsHexes: string[], options?: SignPsbtOptions[]): Promise<string[]> => {
     if (!this.walletInfo)
       throw new WalletError({
         code: ERROR_CODES.WALLET_NOT_CONNECTED,
@@ -146,10 +152,12 @@ export class UnisatProvider implements IBTCProvider {
 
     const network = await this.getNetwork();
     try {
-      return await this.provider.signPsbts(
-        psbtsHexes,
-        psbtsHexes.map((psbtHex) => this.getSignPsbtDefaultOptions(psbtHex, network)),
-      );
+      const defaultOptions = psbtsHexes.map((psbtHex) => this.getSignPsbtDefaultOptions(psbtHex, network));
+      const signOptions = options?.map((option, index) => ({
+        ...defaultOptions[index],
+        ...option,
+      }));
+      return await this.provider.signPsbts(psbtsHexes, signOptions);
     } catch (error: Error | any) {
       throw new WalletError({
         code: ERROR_CODES.SIGNATURE_EXTRACT_ERROR,


### PR DESCRIPTION
Adds an information about the signing contract. Right now works on the BTC Mainnet only.

UI:
<img width="1072" alt="00-before" src="https://github.com/user-attachments/assets/e85f023e-a8e6-445c-b4b1-5480d257cb7e" />
<img width="1072" alt="01-after-modal" src="https://github.com/user-attachments/assets/a03e51d4-4dff-46db-b228-d2454eee1d51" />
<img width="1072" alt="02-after-info" src="https://github.com/user-attachments/assets/2aa4c96b-5b3b-4a79-bff9-21d604f23290" />

Closes #352 

`simple-staking` usage draft PR: https://github.com/babylonlabs-io/simple-staking/pull/923