### PR TITLE
fix: update btc-staking-ts peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "vite-plugin-node-polyfills": "^0.22.0"
       },
       "peerDependencies": {
-        "@babylonlabs-io/btc-staking-ts": "1.0.8",
+        "@babylonlabs-io/btc-staking-ts": "1.0.9",
         "@babylonlabs-io/core-ui": "1.1.1",
         "bitcoinjs-lib": "6.1.5",
         "react": "^18.3.1",
@@ -440,21 +440,19 @@
       "peer": true
     },
     "node_modules/@babylonlabs-io/btc-staking-ts": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/btc-staking-ts/-/btc-staking-ts-1.0.8.tgz",
-      "integrity": "sha512-Yq+2DFWcep2o1uP88P27UbHbvYgFQEmqAc6iNx5i2LXPuv8QJN6l1PTmB2+7CxLOTrEX47zjBQwsswK51/jpWw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/btc-staking-ts/-/btc-staking-ts-1.0.9.tgz",
+      "integrity": "sha512-Z08WaqdMR8hfnWuThlMA8hByXKlCht2hvTAOoSjkM6bMFMEkY3a3Fss7QU7LsWHhzaalCWbXKY/07v594iIV8w==",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {
         "@babylonlabs-io/babylon-proto-ts": "1.0.1",
-        "@cosmjs/encoding": "^0.33.0"
+        "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
+        "@cosmjs/encoding": "^0.33.0",
+        "bitcoinjs-lib": "6.1.5"
       },
       "engines": {
         "node": "22.3.0"
-      },
-      "peerDependencies": {
-        "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
-        "bitcoinjs-lib": "6.1.5"
       }
     },
     "node_modules/@babylonlabs-io/btc-staking-ts/node_modules/@cosmjs/encoding": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@babylonlabs-io/btc-staking-ts": "1.0.8",
+    "@babylonlabs-io/btc-staking-ts": "1.0.9",
     "@babylonlabs-io/core-ui": "1.1.1",
     "bitcoinjs-lib": "6.1.5",
     "react": "^18.3.1",


### PR DESCRIPTION
Updates `btc-staking-ts` to `1.0.9` - no `peerDependencies` are used