### PR TITLE
feat: update btc-staking-ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "vite-plugin-node-polyfills": "^0.22.0"
       },
       "peerDependencies": {
-        "@babylonlabs-io/btc-staking-ts": "1.0.12",
+        "@babylonlabs-io/btc-staking-ts": "2.0.0",
         "@babylonlabs-io/core-ui": "1.1.1",
         "bitcoinjs-lib": "6.1.5",
         "react": "^18.3.1",
@@ -440,9 +440,9 @@
       "peer": true
     },
     "node_modules/@babylonlabs-io/btc-staking-ts": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@babylonlabs-io/btc-staking-ts/-/btc-staking-ts-1.0.12.tgz",
-      "integrity": "sha512-x5uhDxbMdPgKUuI+bcIha2aSPUjDcrMqXNvO3ZxUP0NB0/VXoW9Fj4fhdOQ5aa373qi5ZEdTVTkJUfE8HI0X+Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@babylonlabs-io/btc-staking-ts/-/btc-staking-ts-2.0.0.tgz",
+      "integrity": "sha512-hzQxjViOuNhOV8xB1sgp+LE/RaNxtF32vonBMZN52x5oOrSO2hwu56TGQRQ4gPAK7T6keHEPCXM/dzaJFJp8Rw==",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "@babylonlabs-io/btc-staking-ts": "1.0.12",
+    "@babylonlabs-io/btc-staking-ts": "2.0.0",
     "@babylonlabs-io/core-ui": "1.1.1",
     "bitcoinjs-lib": "6.1.5",
     "react": "^18.3.1",


### PR DESCRIPTION
It seems to me that we can move `btc-staking-ts` to dev deps. Wallets shouldn't be responsible for init of BTCCurve